### PR TITLE
Fix cost / treasure bug

### DIFF
--- a/card_classes.py
+++ b/card_classes.py
@@ -223,7 +223,7 @@ class Workshop:
     def execute_action(self, turn, gain_card):
         standard_action_execute(turn,self)
         gain_card = name_to_inst_dict[gain_card]
-        if gain_card.treasure <= 4:
+        if gain_card.cost <= 4:
             turn.player.gain_card(gain_card,4)
 
 
@@ -242,7 +242,7 @@ class Feast:
     def execute_action(self,turn, gain_card):
         standard_action_execute(turn,self)
         gain_card = name_to_inst_dict[gain_card]
-        if gain_card.treasure <= 5:
+        if gain_card.cost <= 5:
             turn.player.gain_card(gain_card,5)
             turn.player.trash_card(turn.player.played_actions,'Feast')
 


### PR DESCRIPTION
Summary:
In execute_action of Workshop and Feast, the player was allowed
to gain a card of maximum 'treasure' value rather than maximum
'cost', which meant that any action could be acquired. This has
now been fixed.
